### PR TITLE
Remove sectnums and sectnumslevel

### DIFF
--- a/preview.yml
+++ b/preview.yml
@@ -39,8 +39,8 @@ asciidoc:
     # page-cdn: /static/assets
     includePDF: false
     nonhtmloutput: ""
-    sectnums: true,
-    sectnumlevel: 3,
+    # sectnums: true, removed so they are off by default
+    # sectnumlevel: 3,
     experimental: ''
     copyright: 2021
     common-license-page-uri: https://neo4j.com/docs/license/


### PR DESCRIPTION
This change means that you need to specify :sectnums: and :sectnumlevel: to add numbers to headers in the page.