### PR TITLE
Increase page toclevels to 3

### DIFF
--- a/preview.yml
+++ b/preview.yml
@@ -35,6 +35,7 @@ asciidoc:
     page-no-canonical: true
     page-origin-private: true
     page-hide-toc: false
+    page-toclevels: 3@ #can be overridden at individual page level
     page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
     # page-cdn: /static/assets
     includePDF: false


### PR DESCRIPTION
h4 will now be included by default in the Contents section