### PR TITLE
Add a review note to the head of all pages

### DIFF
--- a/modules/review-note/partials/notes.adoc
+++ b/modules/review-note/partials/notes.adoc
@@ -1,0 +1,6 @@
+# tag::review[]
+[NOTE]
+====
+This site contains review content for Neo4j Aura documentation.
+====
+# end::review[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,11 @@
         "pause-stream": "0.0.11"
       }
     },
+    "@neo4j-antora/antora-add-notes": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@neo4j-antora/antora-add-notes/-/antora-add-notes-0.1.5.tgz",
+      "integrity": "sha512-E3xI44XQ3FBcgIZDD3Ei8fcO3eOon3v/+LbDXgQPng4yUBgVKpff4ltiCIlB46sraFrvRSqCXOJt3H21ySO5Yg=="
+    },
     "@neo4j-documentation/macros": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@neo4j-documentation/macros/-/macros-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@antora/site-generator-default": "^2.3.3",
     "@neo4j-documentation/macros": "^1.0.0",
     "@neo4j-documentation/remote-include": "^1.0.0",
+    "@neo4j-antora/antora-add-notes": "^0.1.5",
     "express": "^4.17.1",
     "npm-watch": "^0.6.0"
   },

--- a/preview.yml
+++ b/preview.yml
@@ -24,6 +24,7 @@ asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"
   - "@neo4j-documentation/macros"
+  - "@neo4j-antora/antora-add-notes"
   attributes:
     page-theme: docs
     page-type: Docs
@@ -36,7 +37,8 @@ asciidoc:
     page-origin-private: true
     page-hide-toc: false
     page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
-    # page-cdn: /static/assets
+    page-add-notes-module: review-note@
+    page-add-notes-tags: review@
     includePDF: false
     nonhtmloutput: ""
     # sectnums: true, removed so they are off by default


### PR DESCRIPTION
This performs the same function that the extension we use in neo4j-manual-modeling-antora to add a preview comment to `-preview` content.

This method uses an npm project - [neo4j-antora/antora-add-notes](https://www.npmjs.com/package/@neo4j-antora/antora-add-notes) which allows for more flexibility in adding content to files.