### PR TITLE
Added support link to home page

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -188,7 +188,10 @@ Each plan offers different levels of functionality and support:
 | Enterprise with commercial negotiations
 |===
 
-Further details can be found on the https://neo4j.com/cloud/aura/pricing/#pricing-table[Neo4j Aura Pricing] page.
+[NOTE]
+====
+For information on the different levels of support offered in each plan, see xref:support/index.adoc[].
+====
 
 (C) {copyright}
 License: link:{common-license-page-uri}[Creative Commons 4.0]


### PR DESCRIPTION
The home page now links to the support page. Removed the link to the pricing page as the table is now as detailed on the home page and we already link through to the product page from the header image.