### PR TITLE
Add a CTA in the menu panel for the upcoming NODES conference

### DIFF
--- a/preview.yml
+++ b/preview.yml
@@ -58,3 +58,11 @@ asciidoc:
     properties: '{properties}'
     json: '{json}'
     maps: '{maps}'
+    # page-ad-image: https://dist.neo4j.com/wp-content/uploads/20220901150057/Artboard-12.png
+    page-ad-overline-link: https://neo4j.com/nodes-2022
+    page-ad-overline: 16-17 November 2022
+    page-ad-title: NODES 2022
+    page-ad-description: Join us for a free, two-day virtual conference of technical presentations by developers and data scientists, solving problems with graphs.
+    page-ad-link: https://neo4j.com/nodes-2022
+    page-ad-underline-role: button
+    page-ad-underline: Save your space


### PR DESCRIPTION
FYI @adam-cowley @MarkWoulfeNeo4j 

This PR adds a temporary CTA on the Aura docs for the upcoming Nodes conference. To be removed after the conference (16-17th Nov 2022)