### PR TITLE
Adopt 5.0 Python driver in examples

### DIFF
--- a/modules/ROOT/pages/auradb/connecting-applications/python.adoc
+++ b/modules/ROOT/pages/auradb/connecting-applications/python.adoc
@@ -4,7 +4,7 @@
 
 == Prerequisites
 
-- Python 3.6 and above
+- Python 3.7 and above
 
 == Installation
 
@@ -36,7 +36,7 @@ class App:
     def create_friendship(self, person1_name, person2_name):
         with self.driver.session(database="neo4j") as session:
             # Write transactions allow the driver to handle retries and transient errors
-            result = session.write_transaction(
+            result = session.execute_write(
                 self._create_and_return_friendship, person1_name, person2_name)
             for record in result:
                 print("Created friendship between: {p1}, {p2}"
@@ -64,7 +64,7 @@ class App:
 
     def find_person(self, person_name):
         with self.driver.session(database="neo4j") as session:
-            result = session.read_transaction(self._find_and_return_person, person_name)
+            result = session.execute_read(self._find_and_return_person, person_name)
             for record in result:
                 print("Found person: {record}".format(record=record))
 


### PR DESCRIPTION
Applies changes:
 * 5.0 driver dropped Python 3.6 support (EOL)
 * 5.0 driver deprecated `session.read/write_transaction` in favor of `session.execute_read/write`