### PR TITLE
pricing table updated

### DIFF
--- a/modules/ROOT/pages/auradb/index.adoc
+++ b/modules/ROOT/pages/auradb/index.adoc
@@ -79,7 +79,7 @@ Each plan offers different levels of functionality and support:
 | {check-mark}
 
 | Pause database
-| Automatic After 3 days of inactivity
+| Automatic after 3 days of inactivity
 | On demand
 | On demand
 


### PR DESCRIPTION
This page should now match https://neo4j.com/pricing/  minus the support table which is handled in its own dedicated page.

Please check i haven't missed anything