### PR TITLE
Update modify-sitemaps package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@antora/cli": "^3.0.0",
     "@antora/site-generator-default": "^3.0.0",
     "@neo4j-antora/antora-add-notes": "^0.1.6",
-    "@neo4j-antora/antora-modify-sitemaps": "^0.4.3",
+    "@neo4j-antora/antora-modify-sitemaps": "^0.4.4",
     "@neo4j-documentation/macros": "^1.0.2",
     "@neo4j-documentation/remote-include": "^1.0.0",
     "nodemon": "^1.19.4"


### PR DESCRIPTION
Updates the `antora-modify-sitemaps` version to fix a bug where the logger was incorrectly invoked, which could sometimes result in errors and warnings not being correctly logged.