### PR TITLE
Add warning for model storage

### DIFF
--- a/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
+++ b/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
@@ -329,7 +329,7 @@ The https://neo4j.com/docs/graph-data-science/current/model-catalog/store/[`gds.
 ====
 Not all the models can be saved to disk. A list of the supported models can be found on the link:https://neo4j.com/docs/graph-data-science/current/model-catalog/store/#catalog-model-store[GDS manual].
 
-*Warning: If a model cannot be saved to disk, it will be lost when the AuraDS instance is restarted.*
+*If a model cannot be saved to disk, it will be lost when the AuraDS instance is restarted.*
 ====
 
 [.tabbed-example]


### PR DESCRIPTION
Not all the ML models can be stored to disk, but the [relevant section](https://neo4j.com/docs/aura/aurads/tutorials/model-catalog/#_save_a_model_to_disk) of the docs seems to imply that instead.