### PR TITLE
updated snapshot time expiration window

### DIFF
--- a/modules/ROOT/pages/auradb/managing-databases/backup-restore-export.adoc
+++ b/modules/ROOT/pages/auradb/managing-databases/backup-restore-export.adoc
@@ -6,7 +6,7 @@ The data in your AuraDB instance can be backed up, exported, and restored using 
 
 A snapshot is a copy of the data in an instance at a specific point in time.
 
-The *Snapshots* tab within an AuraDB instance shows a list of available snapshots. footnote:[Snapshots are kept in the system for 7 days for Free and Professional plans and 90 days for Enterprise plans. Only the latest snapshot is available for Free instances.]
+The *Snapshots* tab within an AuraDB instance shows a list of available snapshots. footnote:[Snapshots are kept in the system for 7 days for Professional plans and 90 days for Free and Enterprise plans. Only the latest snapshot is available for Free instances.]
 
 To access the *Snapshots* tab:
 


### PR DESCRIPTION
free dbs now have 90 days of snapshot storage.