### PR TITLE
Update FreeDB retention period

### DIFF
--- a/modules/ROOT/pages/auradb/index.adoc
+++ b/modules/ROOT/pages/auradb/index.adoc
@@ -84,7 +84,7 @@ Each plan offers different levels of functionality and support:
 | On demand
 
 | Resume database
-| On demand or auto-deleted after 90 days
+| On demand or auto-deleted after 30 days
 | On demand or auto-resumed after 30 days
 | On demand or auto-resumed after 30 days
 |===

--- a/modules/ROOT/pages/auradb/index.adoc
+++ b/modules/ROOT/pages/auradb/index.adoc
@@ -126,6 +126,11 @@ Each plan offers different levels of functionality and support:
 | {check-mark}
 | {check-mark}
 | {check-mark}
+
+| Aura API
+|
+|
+| Beta
 |===
 
 .Backup

--- a/modules/ROOT/pages/auradb/managing-databases/backup-restore-export.adoc
+++ b/modules/ROOT/pages/auradb/managing-databases/backup-restore-export.adoc
@@ -6,7 +6,7 @@ The data in your AuraDB instance can be backed up, exported, and restored using 
 
 A snapshot is a copy of the data in an instance at a specific point in time.
 
-The *Snapshots* tab within an AuraDB instance shows a list of available snapshots. footnote:[Snapshots are kept in the system for 7 days for Professional plans and 90 days for Free and Enterprise plans. Only the latest snapshot is available for Free instances.]
+The *Snapshots* tab within an AuraDB instance shows a list of available snapshots. footnote:[Snapshots are kept in the system for 7 days for Professional instances, 30 days for Free instances, and 90 days for Enterprise instances. Only the latest snapshot is available for Free instances.]
 
 To access the *Snapshots* tab:
 

--- a/modules/ROOT/pages/auradb/managing-databases/database-actions.adoc
+++ b/modules/ROOT/pages/auradb/managing-databases/database-actions.adoc
@@ -93,7 +93,7 @@ After confirming, the instance begins resuming, which may take a few minutes.
 
 [WARNING]
 ====
-AuraDB Free instances do not automatically resume after 30 days. If an AuraDB Free instance remains paused for more than 90 days, Aura deletes the instance, and all information is lost.
+AuraDB Free instances do not automatically resume after 30 days. If an AuraDB Free instance remains paused for more than 30 days, Aura deletes the instance, and all information is lost.
 ====
 
 == Cloning an instance


### PR DESCRIPTION
Free instances now cannot hold snapshots for more than 30 days and so delete after that time, rather than the original 90 days.