### PR TITLE
Fixing URL to remove redirect loop

### DIFF
--- a/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
+++ b/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
@@ -423,7 +423,7 @@ IMPORTANT: A model can only be shared with other users of the same AuraDS instan
 
 === Create a new user
 
-In order to see how this works in practice on AuraDS, we first of all need to link:{neo4j-docs-base-uri}/operations-manual/authentication-authorization/manage-users/[create another user^] to share the model with.
+In order to see how this works in practice on AuraDS, we first of all need to link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/manage-users/[create another user^] to share the model with.
 
 [.tabbed-example]
 ====

--- a/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
+++ b/modules/ROOT/pages/aurads/tutorials/model-catalog.adoc
@@ -423,7 +423,7 @@ IMPORTANT: A model can only be shared with other users of the same AuraDS instan
 
 === Create a new user
 
-In order to see how this works in practice on AuraDS, we first of all need to link:{neo4j-docs-base-uri}/cypher-manual/current/administration/security/users-and-roles/[create another user^] to share the model with.
+In order to see how this works in practice on AuraDS, we first of all need to link:{neo4j-docs-base-uri}/operations-manual/authentication-authorization/manage-users/[create another user^] to share the model with.
 
 [.tabbed-example]
 ====


### PR DESCRIPTION
SEMRush flagged a redirect loop from this link that was once in the Cypher manual, but now it's in the Operations manual. Although this doesn't create any errors in navigation, it's bad for search engines crawling, so we should fix it. :)