### PR TITLE
security restructure based on multiple feedback

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -9,9 +9,10 @@ Generic Start
 * xref:platform/cloud-providers.adoc[Cloud provider marketplaces]
 
 * Security
-** xref:platform/security/secure-connections.adoc[]
+** xref:platform/security/private-endpoints.adoc[]
 ** xref:platform/security/single-sign-on.adoc[]
 ** xref:platform/security/encryption.adoc[]
+** xref:platform/security/customer-managed-keys.adoc[]
 
 * xref:platform/user-management.adoc[]
 * xref:platform/apoc.adoc[]

--- a/modules/ROOT/pages/platform/security/customer-managed-keys.adoc
+++ b/modules/ROOT/pages/platform/security/customer-managed-keys.adoc
@@ -17,25 +17,25 @@ Aura has no control over the availability of your externally managed key in the 
 
 [WARNING]
 ====
-The loss of a Customer Managed Key —- through deletion, disabling, or expiration —- makes all data encrypted with that key inaccessible. 
+The loss of a Customer Managed Key makes all data encrypted with that key inaccessible. 
 Neo4j is unable to manage database instances if the key is disabled, deleted, expired, or if permissions are revoked.
 ====
 
-=== Key rotation
+== Key rotation
 
 In your KMS platform, you can either configure automatic rotation for the Customer Managed Key, or you can perform a manual rotation.
 
 Although automatic rotation is not enforced by Aura, it is best practice to rotate keys regularly.
 Manual key rotation is **not** recommended.
 
-=== Import an existing database
+== Import an existing database
 
 You can upload a database to instances encrypted with Customer Managed Keys in Neo4j 5 directly from the console or by using `neo4j-admin database upload`.
 If the database is larger than 4 GB, you have to use `neo4j-admin database upload`. 
 Note that the `neo4j-admin push-to-cloud` command in Neo4j v4.4 and earlier is **not** supported for instances encrypted with Customer Managed Keys.
 For more information see the xref:auradb/importing/import-database.adoc#_neo4j_admin_database_upload[Neo4j Admin `database upload`] documentation.
 
-=== Clone an instance protected by CMK
+== Clone an instance protected by CMK
 
 To clone an instance protected by a Customer Managed Key, the key must be valid and available to Aura.
 The cloned instance, by default, uses the available Customer Managed Key for that region and product.
@@ -43,11 +43,11 @@ The cloned instance, by default, uses the available Customer Managed Key for tha
 It is best practice to use the same CMK key as the instance it’s being cloned from. 
 You can override this to use another CMK key - but you can not use the Neo4j Managed Key.
 
-=== Remove a CMK from Aura
+== Remove a CMK from Aura
 
 When using a Customer Managed Key within Aura to encrypt one or more Aura database instances, it cannot be removed from Aura. 
 If you no longer need to use this Customer Managed Key to encrypt Aura databases, first delete the Aura database instances that are encrypted with the key, then you can remove the key from Aura.
-Keep in mind that this process only breaks the link between the key and Aura —- it does not delete the actual key from the Cloud KMS.
+Keep in mind that this process only breaks the link between the key and Aura, it does not delete the actual key from the Cloud KMS.
 
 == AWS keys
 

--- a/modules/ROOT/pages/platform/security/customer-managed-keys.adoc
+++ b/modules/ROOT/pages/platform/security/customer-managed-keys.adoc
@@ -1,0 +1,159 @@
+[[aura-customer-managed-keys]]
+= Customer Managed Keys
+:description: VPC boundaries enable you to operate within an isolated section of the service.
+
+label:AuraDB-Virtual-Dedicated-Cloud[]
+label:AuraDS-Enterprise[]
+
+A Customer Managed Key (CMK) gives you more control over key operations than the standard Neo4j encryption.
+These are created and managed using a supported cloud key management service (KMS). 
+Externally, Customer Managed Keys are also known as Customer Managed Encryption Keys (CMEK).
+
+When using a Customer Managed Key, all data at rest is encrypted with the key.
+Customer Managed Keys are supported for v4.x and v5.x instances.
+
+When using Customer Managed Keys, you give Aura permission to encrypt and decrypt using the key, but Aura has no access to the key’s material.
+Aura has no control over the availability of your externally managed key in the KMS.
+
+[WARNING]
+====
+The loss of a Customer Managed Key —- through deletion, disabling, or expiration —- makes all data encrypted with that key inaccessible. 
+Neo4j is unable to manage database instances if the key is disabled, deleted, expired, or if permissions are revoked.
+====
+
+=== Key rotation
+
+In your KMS platform, you can either configure automatic rotation for the Customer Managed Key, or you can perform a manual rotation.
+
+Although automatic rotation is not enforced by Aura, it is best practice to rotate keys regularly.
+Manual key rotation is **not** recommended.
+
+=== Import an existing database
+
+You can upload a database to instances encrypted with Customer Managed Keys in Neo4j 5 directly from the console or by using `neo4j-admin database upload`.
+If the database is larger than 4 GB, you have to use `neo4j-admin database upload`. 
+Note that the `neo4j-admin push-to-cloud` command in Neo4j v4.4 and earlier is **not** supported for instances encrypted with Customer Managed Keys.
+For more information see the xref:auradb/importing/import-database.adoc#_neo4j_admin_database_upload[Neo4j Admin `database upload`] documentation.
+
+=== Clone an instance protected by CMK
+
+To clone an instance protected by a Customer Managed Key, the key must be valid and available to Aura.
+The cloned instance, by default, uses the available Customer Managed Key for that region and product.
+
+It is best practice to use the same CMK key as the instance it’s being cloned from. 
+You can override this to use another CMK key - but you can not use the Neo4j Managed Key.
+
+=== Remove a CMK from Aura
+
+When using a Customer Managed Key within Aura to encrypt one or more Aura database instances, it cannot be removed from Aura. 
+If you no longer need to use this Customer Managed Key to encrypt Aura databases, first delete the Aura database instances that are encrypted with the key, then you can remove the key from Aura.
+Keep in mind that this process only breaks the link between the key and Aura —- it does not delete the actual key from the Cloud KMS.
+
+== AWS keys
+
+=== Create an AWS key
+
+. Create a key in the AWS KMS making sure the region matches your Aura database instance.
+Copy the generated ARN.
+You need it in the next step.
+. Go to *security settings* in the Aura Console, add a *Customer Managed Key* and copy the JSON code that is generated in the Aura Console when you add a key.
+. In the AWS KMS, edit the key policy to include the JSON code.
+
+=== Edit the AWS key policy
+
+After you have initially created a key in the AWS KMS, you can edit the key policy.
+In the AWS key policy, "Statement" is an array that consists of one or more objects.
+Each object in the array describes a security identifier (SID).
+The objects in the AWS code array are comma-separated, e.g. `{[{'a'}, {'b'}, {'c'}]}`
+
+Add a comma after the curly brace in the final SID, and then paste the JSON code that was generated in the Aura Console (for example `{[{'a'}, {'b'}, {'c'}, _add code here_ ]}`).
+
+=== AWS regions
+
+Aura supports AWS Customer Managed Keys that reside in the same region as the instance.
+When creating a Customer Managed Key in the AWS KMS, you can create a single-region key, or create a multi-region key.
+
+Single-region keys reside in only one AWS region, which must be the same region as your Aura instance.
+
+Multi-region keys have a primary region, however these can be replicated to other regions that match the region of your Aura instance.
+The replicas share the same key ID and different Amazon Resource Names (ARNs) with the primary key.
+
+=== AWS automatic key rotation
+
+Aura supports automatic key rotation via the AWS KMS.
+To enable automatic key rotation in the AWS KMS, tick the *Key rotation* checkbox after initially creating a key, to automatically rotate the key once a year.
+
+== Azure keys
+
+=== Create an Azure key vault
+
+Create a Key Vault in the Azure portal ensuring the region matches your Aura database instance region. 
+Move through the tabs to enable to following:
+
+* Purge protection
+* Azure role-based access control
+* Azure Disk Encryption for volume encryption
+* Allow access from all networks
+
+=== Create a key
+
+. When preparing to create a key, if needed grant a role assignment:
+.. Inside the key vault, go to *Access Control (IAM)* and *add role assignment*.
+.. In the *Role* tab, select *Key Vault Administrator*.
+.. In the *Member* tab, select *User, group, or service principal*.
+.. *Select members* and select yourself or the relevant person, then *Review + Assign*.
+
+. Create a key in the Azure Key Vault. 
+. After the key is created, click into key version and copy the *Key Identifier*, you need it in the next step.
+. Go to *security settings* in the Aura Console and add a *Customer Managed Key*.
+. Follow the instructions in the Aura Console for the next sections.
+
+=== Create a service principal
+
+In the Azure Entra ID tenant where your key is located, create a service principal linked to the Neo4j CMK Application with the *Neo4j CMK Application ID* displayed in the Aura Console.
+
+One way to do this is by clicking the terminal icon at the top of the Azure portal, to open the Azure Cloud Shell.
+
+Using Azure CLI, the command is: 
+
+[source,bash]
+----
+az ad sp create --id Neo4jCMKApplicationID
+----
+For more information about the Azure CLI, see link:https://learn.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create[`az ad sp` documentation].
+
+=== Grant key permissions
+
+. To add role assignment to the Azure key, inside the key, go to *Access control (IAM)* and add *role assignment*.
+. In the *Role* tab, select *Key Vault Crypto Officer*.
+. In the *Member* tab, select *User, group, or service principal*.
+. *Select members* and paste the *Neo4j CMK Application name* that is displayed in the Aura Console. 
+. The *Neo4j CMK Application* should appear, select this application then *Review + Assign*.
+
+== GCP keys
+
+=== Create a key ring
+
+. Go to *Key Management* in the Google Cloud console.
+. Create a *key ring*.
+. The key ring *Location type* should be set to *Region.*
+. Make sure the region matches your Aura database instance region. 
+. Select *Create* and you are automatically taken to the key creation page. 
+
+=== Create a key
+
+. Create a key in the Google Console. 
+You can use default settings for the options, but setting a key rotation period is recommended. 
+. Select *Create* and you are brought to the key ring, with your key listed. 
+. Click *More* (three dots) and *Copy resource name*, you need it in the next step. 
+For more information, see link:https://cloud.google.com/kms/docs/getting-resource-ids[Google Cloud docs]
+. Go to *security settings* in the Aura Console and add a *Customer Managed Key*. 
+Paste the *resource name* into the *Encryption Key Resource Name* field.
+. After you select *Add Key* in the Aura Console, three *service accounts* are displayed in the Aura Console. 
+You will need these in the next steps.
+
+=== Grant key permissions
+
+. Go to the Google Cloud console, click into the key and go to *Permissions* then *Grant Access*. 
+. In *Add principals* paste the three service accounts from the Aura Console.
+. In *Assign roles* assign both *Cloud KMS CryptoKey Encrypter/Decrypter* and *Cloud KMS Viewer* roles to all three service accounts.

--- a/modules/ROOT/pages/platform/security/encryption.adoc
+++ b/modules/ROOT/pages/platform/security/encryption.adoc
@@ -6,163 +6,26 @@ All data stored in Neo4j Aura is encrypted using intra-cluster encryption betwee
 
 By default, each cloud provider encrypts all backup buckets (including the objects stored inside) using either link:https://cloud.google.com/storage/docs/encryption/default-keys[Google-managed encryption], link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html[AWS SSE-S3 encryption], or link:https://learn.microsoft.com/en-us/azure/storage/common/storage-service-encryption[Azure Storage encryption].
 
-== Customer Managed Keys
+== Supported TLS cipher suites
 
-label:AuraDB-Virtual-Dedicated-Cloud[]
-label:AuraDS-Enterprise[]
+For additional security, client communications are carried via TLS v1.2 and TLS v1.3.
 
-A Customer Managed Key (CMK) gives you more control over key operations than the standard Neo4j encryption.
-These are created and managed using a supported cloud key management service (KMS). 
-Externally, Customer Managed Keys are also known as Customer Managed Encryption Keys (CMEK).
+AuraDB has a restricted list of cipher suites accepted during the TLS handshake, and does not accept all of the available cipher suites.
+The following list conforms to safety recommendations from IANA, the OpenSSL, and GnuTLS library.
 
-When using a Customer Managed Key, all data at rest is encrypted with the key.
-Customer Managed Keys are supported for v4.x and v5.x instances.
+TLS v1.3:
 
-When using Customer Managed Keys, you give Aura permission to encrypt and decrypt using the key, but Aura has no access to the key’s material.
-Aura has no control over the availability of your externally managed key in the KMS.
+* `TLS_CHACHA20_POLY1305_SHA256 (RFC8446)`
+* `TLS_AES_128_GCM_SHA256 (RFC8446)`
+* `TLS_AES_256_GCM_SHA384 (RFC8446)`
 
-[WARNING]
-====
-The loss of a Customer Managed Key —- through deletion, disabling, or expiration —- makes all data encrypted with that key inaccessible. 
-Neo4j is unable to manage database instances if the key is disabled, deleted, expired, or if permissions are revoked.
-====
+TLS v1.2:
 
-=== Key rotation
-
-In your KMS platform, you can either configure automatic rotation for the Customer Managed Key, or you can perform a manual rotation.
-
-Although automatic rotation is not enforced by Aura, it is best practice to rotate keys regularly.
-Manual key rotation is **not** recommended.
-
-=== Import an existing database
-
-You can upload a database to instances encrypted with Customer Managed Keys in Neo4j 5 directly from the console or by using `neo4j-admin database upload`.
-If the database is larger than 4 GB, you have to use `neo4j-admin database upload`. 
-Note that the `neo4j-admin push-to-cloud` command in Neo4j v4.4 and earlier is **not** supported for instances encrypted with Customer Managed Keys.
-For more information see the xref:auradb/importing/import-database.adoc#_neo4j_admin_database_upload[Neo4j Admin `database upload`] documentation.
-
-=== Clone an instance protected by CMK
-
-To clone an instance protected by a Customer Managed Key, the key must be valid and available to Aura.
-The cloned instance, by default, uses the available Customer Managed Key for that region and product.
-
-It is best practice to use the same CMK key as the instance it’s being cloned from. 
-You can override this to use another CMK key - but you can not use the Neo4j Managed Key.
-
-=== Remove a CMK from Aura
-
-When using a Customer Managed Key within Aura to encrypt one or more Aura database instances, it cannot be removed from Aura. 
-If you no longer need to use this Customer Managed Key to encrypt Aura databases, first delete the Aura database instances that are encrypted with the key, then you can remove the key from Aura.
-Keep in mind that this process only breaks the link between the key and Aura —- it does not delete the actual key from the Cloud KMS.
-
-== AWS keys
-
-=== Create an AWS key
-
-. Create a key in the AWS KMS making sure the region matches your Aura database instance.
-Copy the generated ARN.
-You need it in the next step.
-. Go to *security settings* in the Aura Console, add a *Customer Managed Key* and copy the JSON code that is generated in the Aura Console when you add a key.
-. In the AWS KMS, edit the key policy to include the JSON code.
-
-=== Edit the AWS key policy
-
-After you have initially created a key in the AWS KMS, you can edit the key policy.
-In the AWS key policy, "Statement" is an array that consists of one or more objects.
-Each object in the array describes a security identifier (SID).
-The objects in the AWS code array are comma-separated, e.g. `{[{'a'}, {'b'}, {'c'}]}`
-
-Add a comma after the curly brace in the final SID, and then paste the JSON code that was generated in the Aura Console (for example `{[{'a'}, {'b'}, {'c'}, _add code here_ ]}`).
-
-=== AWS regions
-
-Aura supports AWS Customer Managed Keys that reside in the same region as the instance.
-When creating a Customer Managed Key in the AWS KMS, you can create a single-region key, or create a multi-region key.
-
-Single-region keys reside in only one AWS region, which must be the same region as your Aura instance.
-
-Multi-region keys have a primary region, however these can be replicated to other regions that match the region of your Aura instance.
-The replicas share the same key ID and different Amazon Resource Names (ARNs) with the primary key.
-
-=== AWS automatic key rotation
-
-Aura supports automatic key rotation via the AWS KMS.
-To enable automatic key rotation in the AWS KMS, tick the *Key rotation* checkbox after initially creating a key, to automatically rotate the key once a year.
-
-== Azure keys
-
-=== Create an Azure key vault
-
-Create a Key Vault in the Azure portal ensuring the region matches your Aura database instance region. 
-Move through the tabs to enable to following:
-
-* Purge protection
-* Azure role-based access control
-* Azure Disk Encryption for volume encryption
-* Allow access from all networks
-
-=== Create a key
-
-. When preparing to create a key, if needed grant a role assignment:
-.. Inside the key vault, go to *Access Control (IAM)* and *add role assignment*.
-.. In the *Role* tab, select *Key Vault Administrator*.
-.. In the *Member* tab, select *User, group, or service principal*.
-.. *Select members* and select yourself or the relevant person, then *Review + Assign*.
-
-. Create a key in the Azure Key Vault. 
-. After the key is created, click into key version and copy the *Key Identifier*, you need it in the next step.
-. Go to *security settings* in the Aura Console and add a *Customer Managed Key*.
-. Follow the instructions in the Aura Console for the next sections.
-
-=== Create a service principal
-
-In the Azure Entra ID tenant where your key is located, create a service principal linked to the Neo4j CMK Application with the *Neo4j CMK Application ID* displayed in the Aura Console.
-
-One way to do this is by clicking the terminal icon at the top of the Azure portal, to open the Azure Cloud Shell.
-
-Using Azure CLI, the command is: 
-
-[source,bash]
-----
-az ad sp create --id Neo4jCMKApplicationID
-----
-For more information about the Azure CLI, see link:https://learn.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create[`az ad sp` documentation].
-
-=== Grant key permissions
-
-. To add role assignment to the Azure key, inside the key, go to *Access control (IAM)* and add *role assignment*.
-. In the *Role* tab, select *Key Vault Crypto Officer*.
-. In the *Member* tab, select *User, group, or service principal*.
-. *Select members* and paste the *Neo4j CMK Application name* that is displayed in the Aura Console. 
-. The *Neo4j CMK Application* should appear, select this application then *Review + Assign*.
-
-== GCP keys
-
-=== Create a key ring
-
-. Go to *Key Management* in the Google Cloud console.
-. Create a *key ring*.
-. The key ring *Location type* should be set to *Region.*
-. Make sure the region matches your Aura database instance region. 
-. Select *Create* and you are automatically taken to the key creation page. 
-
-=== Create a key
-
-. Create a key in the Google Console. 
-You can use default settings for the options, but setting a key rotation period is recommended. 
-. Select *Create* and you are brought to the key ring, with your key listed. 
-. Click *More* (three dots) and *Copy resource name*, you need it in the next step. 
-For more information, see link:https://cloud.google.com/kms/docs/getting-resource-ids[Google Cloud docs]
-. Go to *security settings* in the Aura Console and add a *Customer Managed Key*. 
-Paste the *resource name* into the *Encryption Key Resource Name* field.
-. After you select *Add Key* in the Aura Console, three *service accounts* are displayed in the Aura Console. 
-You will need these in the next steps.
-
-=== Grant key permissions
-
-. Go to the Google Cloud console, click into the key and go to *Permissions* then *Grant Access*. 
-. In *Add principals* paste the three service accounts from the Aura Console.
-. In *Assign roles* assign both *Cloud KMS CryptoKey Encrypter/Decrypter* and *Cloud KMS Viewer* roles to all three service accounts.
+* `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (RFC5288)`
+* `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (RFC5289)`
+* `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (RFC5289)`
+* `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (RFC7905)`
+* `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (RFC5288)`
 
 
 

--- a/modules/ROOT/pages/platform/security/private-endpoints.adoc
+++ b/modules/ROOT/pages/platform/security/private-endpoints.adoc
@@ -1,4 +1,4 @@
-[[aura-reference-security]]
+[[aura-private-endpoints]]
 = Private endpoints
 :description: VPC boundaries enable you to operate within an isolated section of the service.
 

--- a/modules/ROOT/pages/platform/security/private-endpoints.adoc
+++ b/modules/ROOT/pages/platform/security/private-endpoints.adoc
@@ -1,5 +1,5 @@
 [[aura-reference-security]]
-= Secure connections
+= Private endpoints
 :description: VPC boundaries enable you to operate within an isolated section of the service.
 
 == VPC isolation
@@ -214,23 +214,4 @@ To enable private endpoints using Azure Private Link:
 
 Please see the link:https://learn.microsoft.com/en-us/azure/private-link/rbac-permissions#private-endpoint[Azure Documentation] for required roles and permissions.
 
-== Supported TLS cipher suites
 
-For additional security, client communications are carried via TLS v1.2 and TLS v1.3.
-
-AuraDB has a restricted list of cipher suites accepted during the TLS handshake, and does not accept all of the available cipher suites.
-The following list conforms to safety recommendations from IANA, the OpenSSL, and GnuTLS library.
-
-TLS v1.3:
-
-* `TLS_CHACHA20_POLY1305_SHA256 (RFC8446)`
-* `TLS_AES_128_GCM_SHA256 (RFC8446)`
-* `TLS_AES_256_GCM_SHA384 (RFC8446)`
-
-TLS v1.2:
-
-* `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (RFC5288)`
-* `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (RFC5289)`
-* `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (RFC5289)`
-* `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (RFC7905)`
-* `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (RFC5288)`


### PR DESCRIPTION
Hey @AlexicaWright I'd like to slighty edit the structure of the security docs - my hypothesis is that is Customer Managed Keys has it's own section more people might find the functionality 

Also I'd like to rename "Secure Connections" to "Private endpoints" making this info more easy to search and reference - based on Sumeet's feedback

I'm mindful of re-directs this time!