### PR TITLE
Document the metric "neo4j_cluster_raft_is_leader"

### DIFF
--- a/modules/ROOT/pages/platform/metrics-integration.adoc
+++ b/modules/ROOT/pages/platform/metrics-integration.adoc
@@ -751,3 +751,21 @@ It should show overlapping, ever-increasing lines and if one of the lines levels
 | Default aggregation
 m| MAX
 |===
+
+.Cluster Leader (only included if <<_metrics_granularity,high granularity>> is turned on)
+[frame="topbot", stripes=odd, grid="cols", cols="<1,<4"]
+|===
+| Metric name
+m| neo4j_cluster_raft_is_leader
+| Description
+| Is this server the leader?
+Track this for each core cluster member.
+It will report 0 if it is not the leader and 1 if it is the leader.
+The sum of all of these should always be 1.
+However, there will be transient periods in which the sum can be more than 1 because more than one member thinks it is the leader.
+Action may be needed if the metric shows 0 for more than 30 seconds.
+| Metric type
+| _Gauge_
+| Default aggregation
+m| MAX
+|===


### PR DESCRIPTION
[Trello card](https://trello.com/c/mvAZWB5H/2487-nom-metrics-leadership-integration)