### PR TITLE
console preview: ops qla download

### DIFF
--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -256,7 +256,9 @@ To see the whole query if the query is longer, press the *View more* button unde
 
 == Download logs
 
-Query logs analyzer allows you to download the <<fetch-logs,fetched logs>>. The downloaded logs will account for any <<filters,filters>> and <<search,search>> that have been applied. Downloading logs consists of two steps: initiate the download and download the file.
+Query logs analyzer allows you to download the <<fetch-logs, fetched logs>>. 
+The downloaded logs account for any <<filters, filters>> and <<search, search>> that have been applied. 
+Downloading logs consists of two steps: **initiate the download** and **download the file**.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -102,7 +102,8 @@ The fields are case insensitive.
 
 The log tables provide two different views of your query data:
 
-* The *Summary table* aggregates similar queries, showing statistics like average execution time and total count. This view helps identify patterns and potential performance issues across multiple executions of the same query.
+* The *Summary table* aggregates similar queries, showing statistics like average execution time and total count. 
+This view helps identify patterns and potential performance issues across multiple executions of the same query.
 
 * The *Details table* shows individual query executions with their specific timestamps, users, and performance metrics. This granular view is useful for investigating specific incidents or understanding the context of individual query executions.
 

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -1,3 +1,10 @@
+:role-project-admin: Project Admin
+:role-project-member: Project Member
+:log-retention-days: 30
+:max-request-hours: 24
+:max-download-rows: 5 million
+:log-download-retention-days: 30
+
 [[aura-monitoring]]
 = Query log analyzer
 
@@ -60,6 +67,7 @@ To reset zoom, double-click anywhere inside the timeline.
 To hide or show individual data series, select the corresponding data series in the legend below the timeline.
 
 
+[[fetch-logs]]
 == Fetch logs
 
 The *Fetch logs* button opens up a dialog where you can add filters and search before fetching the logs.
@@ -68,9 +76,10 @@ To fetch the logs after selection of filters and search is done, click the *Go* 
 
 [NOTE]
 ====
-Query logs are available for a period of 7 days, and each request can be for up to 24 hours of data.
+Query logs are available for a period of {log-retention-days} days, and each request can be for up to {max-request-hours} hours of data.
 ====
 
+[[filters]]
 === Filters
 
 Use the filter button to load the available filters over the selected time period.
@@ -82,11 +91,150 @@ Filters are available for the following fields:
 * Application
 * Initiation type
 
+[[search]]
 === Search
 
 Use the search button to search for specific queries or errors.
 Search can be specified for the *Query text* and the *Error text*.
 The fields are case insensitive.
+
+== Log tables
+
+The log tables provide two different views of your query data:
+
+* The *Summary table* aggregates similar queries, showing statistics like average execution time and total count. This view helps identify patterns and potential performance issues across multiple executions of the same query.
+
+* The *Details table* shows individual query executions with their specific timestamps, users, and performance metrics. This granular view is useful for investigating specific incidents or understanding the context of individual query executions.
+
+Both tables can be customized using filters and column preferences to focus on the data most relevant to your analysis.
+
+=== Summary
+
+.Summary table columns
+[cols="25,25m,50v"]
+|===
+| Display Name | Field Name | Description
+
+| Status
+| severity
+| The status of the query execution.
+
+| Query
+| query
+| The full query text.
+
+| Count
+| executionCount
+| The number of times this query was executed.
+
+| From
+| fromTime
+| The start timestamp of the first query execution.
+
+| To
+| toTime
+| The end timestamp of the last query execution.
+
+| Total time spent (s)
+| totalTimeSpent
+| The total time spent executing all instances of this query, in seconds.
+
+| Avg time (ms)
+| avgExecutionTimeMs
+| The average execution time of the query, in milliseconds.
+
+| Min time (ms)
+| minExecutionTimeMs
+| The minimum execution time of the query, in milliseconds.
+
+| Max time (ms)
+| maxExecutionTimeMs
+| The maximum execution time of the query, in milliseconds.
+
+| Avg waiting (ms)
+| avgWaitingTimeMs
+| The average time spent waiting before query execution, in milliseconds.
+
+| Avg bytes
+| avgAllocatedBytes
+| The average number of bytes allocated per query execution.
+
+| Avg page hits
+| avgPageHits
+| The average number of page hits per query execution.
+
+| Avg page faults
+| avgPageFaults
+| The average number of page faults per query execution.
+
+| Actions
+| -
+| Contains an icon button (Arrow Right Circle) to view detailed executions of this specific query in the Details table. When clicked, the Details table will be filtered to show only executions of the selected query.
+|===
+
+=== Details
+
+.Details table columns
+[cols="25,25m,50v"]
+|===
+| Display Name | Field Name | Description
+
+| Status
+| severity
+| The status of the query execution.
+
+| Query
+| query
+| The full query text.
+
+| End time
+| endTime
+| The timestamp when the query execution completed, including milliseconds.
+
+| Duration (ms)
+| executionTimeMs
+| The duration of the query execution in milliseconds.
+
+| Planning (ms)
+| planningTimeMs
+| The time spent planning the query execution in milliseconds.
+
+| Waiting (ms)
+| waitingTimeMs
+| The time spent waiting before query execution in milliseconds.
+
+| User
+| authenticatedUser
+| The user who executed the query.
+
+| Database
+| database
+| The database where the query was executed.
+
+| Driver
+| driver
+| The database driver used to execute the query.
+
+| Application
+| app
+| The application that initiated the query.
+
+| Initiation type
+| initiationType
+| The type of query initiation.
+
+| Alloc bytes
+| allocatedBytes
+| The number of bytes allocated during query execution.
+
+| Page hits
+| pageHits
+| The number of page hits during query execution.
+
+| Page faults
+| pageFaults
+| The number of page faults during query execution.
+|===
 
 == Table interactions
 
@@ -106,3 +254,74 @@ In the table three rows of query text will be shown.
 To see the whole query if the query is longer, press the *View more* button under the query text.
 
 
+== Download logs
+
+Query logs analyzer allows you to download the <<fetch-logs,fetched logs>>. The downloaded logs will account for any <<filters,filters>> and <<search,search>> that have been applied. Downloading logs consists of two steps: initiate the download and download the file.
+
+[NOTE]
+====
+Downloading logs requires a project role of either _{role-project-admin}_ or _{role-project-member}_.
+====
+
+=== Initiate download
+
+To initiate a download, after fetching the logs, click the _Initiate log download_ icon button (Arrow Down Tray Icon) in the top right corner of either the Summary or Details table. On the dialog that opens, select the following options:
+
+* *Log type* - Select one or both:
+** *Summary* - Aggregated query statistics
+** *Details* - Individual query executions
+* *Format* - Choose your preferred format:
+** *JSON*
+** *CSV* with optional settings:
+*** Include CSV headers (default: enabled)
+*** CSV field delimiter (default: comma)
+
+Click *Confirm* to start the download. Once the download has been initiated, the modal closes and the _Downloads archive_ side drawer opens automatically.
+
+[NOTE]
+====
+Each download request is limited to {max-request-hours} hours of data and a maximum of {max-download-rows} rows.
+====
+
+=== Download the file
+
+To view your downloads, click the _Open downloads archive_ icon button (Document Text Icon) in the top right corner of the page. The _Downloads archive_ side drawer opens, displaying a table with all downloads for the currently selected instance. The table includes the following information for each download:
+
+.Downloads archive table columns
+[cols="25,75v"]
+|===
+| Display Name | Description
+
+| Requested
+| When the download was requested and by which user.
+
+| Status
+| Current status of the download (e.g., Running, Completed, Failed).
+
+| Type
+| The type of query logs being downloaded (Summary or Details).
+
+| Time Period
+| The time range covered by the downloaded logs.
+
+| Rows
+| Number of log entries exported.
+
+| Format
+| File format of the download (JSON or CSV with additional CSV settings).
+
+| Filters
+| Applied filters for the log download.
+
+| Actions
+| _Download log_ icon button (Arrow Down Tray Icon) and _Delete log_ icon button (Trash Icon) for the log file.
+|===
+
+You can download log files by selecting the download icon in the Actions column once the status shows _Ready_. Downloaded query logs are provided as a zipped file in your chosen format (JSON or CSV), containing the same fields shown in the Field Name columns of the Summary and Details tables above. The file name follows this pattern: `<db_id>-<timestamp>-query-logs-<log_type>.<format>.gz`, for example: `dd9ba752-1731586207476-query-logs-details.json.gz`
+
+To delete a log file, select the delete icon in the Actions column.
+
+[NOTE]
+====
+Log files are automatically deleted from the downloads archive after {log-download-retention-days} days.
+====

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -105,7 +105,8 @@ The log tables provide two different views of your query data:
 * The *Summary table* aggregates similar queries, showing statistics like average execution time and total count. 
 This view helps identify patterns and potential performance issues across multiple executions of the same query.
 
-* The *Details table* shows individual query executions with their specific timestamps, users, and performance metrics. This granular view is useful for investigating specific incidents or understanding the context of individual query executions.
+* The *Details table* shows individual query executions with their specific timestamps, users, and performance metrics. 
+This granular view is useful for investigating specific incidents or understanding the context of individual query executions.
 
 === Summary
 

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -323,7 +323,9 @@ The table includes the following information for each download:
 | _Download log_ icon button (Arrow Down Tray Icon) and _Delete log_ icon button (Trash Icon) for the log file.
 |===
 
-You can download log files by selecting the download icon in the Actions column once the status shows _Ready_. Downloaded query logs are provided as a zipped file in your chosen format (JSON or CSV), containing the same fields shown in the Field Name columns of the Summary and Details tables above. The file name follows this pattern: `<db_id>-<timestamp>-query-logs-<log_type>.<format>.gz`, for example: `dd9ba752-1731586207476-query-logs-details.json.gz`
+You can download log files by selecting the download icon in the Actions column once the status shows _Ready_. 
+Downloaded query logs are provided as a zipped file in your chosen format (JSON or CSV), containing the same fields shown in the Field Name columns of the Summary and Details tables above. 
+The file name follows this pattern: `<db_id>-<timestamp>-query-logs-<log_type>.<format>.gz`, for example: `dd9ba752-1731586207476-query-logs-details.json.gz`
 
 To delete a log file, select the delete icon in the Actions column.
 

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -169,7 +169,7 @@ This granular view is useful for investigating specific incidents or understandi
 
 | Actions
 | -
-| Contains an icon button (Arrow Right Circle) to view detailed executions of this specific query in the Details table. When clicked, the Details table will be filtered to show only executions of the selected query.
+| Contains an icon button (Arrow Right Circle) to view detailed executions of this specific query in the Details table. Use this button to filter the Details table to show only executions of the selected query.
 |===
 
 === Details

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -265,7 +265,8 @@ Downloading logs requires a project role of either _{role-project-admin}_ or _{r
 
 === Initiate download
 
-To initiate a download, after fetching the logs, click the _Initiate log download_ icon button (Arrow Down Tray Icon) in the top right corner of either the Summary or Details table. On the dialog that opens, select the following options:
+To initiate a download, after fetching the logs, click the _Initiate log download_ icon button (Arrow Down Tray Icon) in the top right corner of either the Summary or Details table. 
+In the dialog that opens, select the following options:
 
 * *Log type* - Select one or both:
 ** *Summary* - Aggregated query statistics

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -289,7 +289,9 @@ Each download request is limited to {max-request-hours} hours of data and a maxi
 
 === Download the file
 
-To view your downloads, click the _Open downloads archive_ icon button (Document Text Icon) in the top right corner of the page. The _Downloads archive_ side drawer opens, displaying a table with all downloads for the currently selected instance. The table includes the following information for each download:
+Use the _Open downloads archive_ icon button (Document Text Icon) in the top right corner of the page, to view your downloads. 
+The _Downloads archive_ side drawer opens, displaying a table with all downloads for the currently selected instance. 
+The table includes the following information for each download:
 
 .Downloads archive table columns
 [cols="25,75v"]

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -279,7 +279,8 @@ In the dialog that opens, select the following options:
 *** Include CSV headers (default: enabled)
 *** CSV field delimiter (default: comma)
 
-Click *Confirm* to start the download. Once the download has been initiated, the modal closes and the _Downloads archive_ side drawer opens automatically.
+Click *Confirm* to start the download. 
+Once the download has been initiated, the modal closes, and the _Downloads archive_ side drawer opens automatically.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/logging/query-log-analyzer.adoc
+++ b/modules/ROOT/pages/logging/query-log-analyzer.adoc
@@ -106,8 +106,6 @@ The log tables provide two different views of your query data:
 
 * The *Details table* shows individual query executions with their specific timestamps, users, and performance metrics. This granular view is useful for investigating specific incidents or understanding the context of individual query executions.
 
-Both tables can be customized using filters and column preferences to focus on the data most relevant to your analysis.
-
 === Summary
 
 .Summary table columns


### PR DESCRIPTION
This PR
- extends the query log download docs with two tables, each having the columns **Display Name**, **Field Name** and **Description**,  which document the columns in the QLA Summary and Details tables. **Field Name** lists the name of the fields in the raw query log, which will end up in the downloaded log files.
- adds docs for the query log download feature

Note that the QLA Download feature is behind feature flag.

[Trello](https://trello.com/c/0L7UxU5i/2491-nom-logs-qla-ability-to-download-logs)