### PR TITLE
Update clone instance docs to match the current UI

### DIFF
--- a/modules/ROOT/pages/managing-instances/instance-actions.adoc
+++ b/modules/ROOT/pages/managing-instances/instance-actions.adoc
@@ -134,10 +134,10 @@ You cannot clone from a Neo4j version 5 instance to a Neo4j version 4 instance.
 
 === Clone to a new instance
 
-. From the more menu (*...*) on the instance you want to clone, select *Clone To New* from the contextual.
+. From the more menu (*...*) on the instance you want to clone, select *Clone to* and then *New instance* from the contextual menu.
 . Set your desired settings for the new database.
 For more information on AuraDB database creation, see xref:getting-started/quick-start-guide.adoc#create-instance[Create an instance].
-. Check the *I understand* box and select *Clone Database*.
+. Check the *I accept* box and select *Create*.
 +
 [WARNING]
 ====
@@ -155,17 +155,15 @@ Cloning into an existing instance will replace all existing data.
 If you want to keep the current data, take a snapshot and export it.
 ====
 
-. From the more menu (*...*) on the instance you want to clone, select *Clone To Existing* and then *AuraDB* from the contextual menu.
-. If necessary, change the database name.
+. From the more menu (*...*) on the instance you want to clone, select *Clone to* and then *Existing instance* from the contextual menu.
 . Select the existing AuraDB database to clone to from the dropdown menu.
 +
 [NOTE]
 ====
 Existing instances that are not large enough to clone into will not be available for selection.
-In the dropdown menu, they will be grayed out and have the string `(Instance is not large enough to clone into)` appended to their name.
 ====
 +
-. Check the *I understand* box and select *Clone*.
+. Check the *I understand the target instance will be overwritten.* box and select *Clone*.
 
 == Delete an instance
 

--- a/modules/ROOT/pages/managing-instances/instance-actions.adoc
+++ b/modules/ROOT/pages/managing-instances/instance-actions.adoc
@@ -163,7 +163,7 @@ If you want to keep the current data, take a snapshot and export it.
 Existing instances that are not large enough to clone into will not be available for selection.
 ====
 +
-. Check the *I understand the target instance will be overwritten.* box and select *Clone*.
+. Check the *I understand the target instance will be overwritten* box and select *Clone*.
 
 == Delete an instance
 

--- a/modules/ROOT/pages/managing-instances/instance-actions.adoc
+++ b/modules/ROOT/pages/managing-instances/instance-actions.adoc
@@ -167,16 +167,6 @@ In the dropdown menu, they will be grayed out and have the string `(Instance is 
 +
 . Check the *I understand* box and select *Clone*.
 
-+
-[NOTE]
-====
-Existing instances that are not large enough to clone into will not be available for selection.
-In the dropdown menu, they are grayed out and have the string `(Instance is not large enough to clone into)` appended to their name.
-====
-+
-. Tick the *I understand* checkbox and select *Clone*.
-
-
 == Delete an instance
 
 Delete an instance using the trashcan icon on the instance card.

--- a/modules/ROOT/pages/managing-instances/instance-actions.adoc
+++ b/modules/ROOT/pages/managing-instances/instance-actions.adoc
@@ -188,4 +188,4 @@ Because updates are applied to these database instances after other database ins
 
 After marking the instance as `production` the label is applied immediately, and all instance actions (such as pause or clone) are temporarily unavailable while the instance is set to `production` in the Neo4j backend. 
 
-Use the more menu (three dots) on the instance card to mark it as `production`.
+Use the more menu (*...*) on the instance card to mark it as `production`.


### PR DESCRIPTION
The step was duplicated:
![image](https://github.com/user-attachments/assets/c872fd9e-607d-4f3a-9979-9b71dd4f9819)

Additionally, did some other changes needed to sync the docs.
