### PR TITLE
Fix image zoom issue for CMI docs

### DIFF
--- a/modules/ROOT/pages/metrics/metrics-integration/examples.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/examples.adoc
@@ -22,7 +22,7 @@ Aura metrics integration examples for various APM platforms.
 
 - Copy the job configuration template provided for the project endpoint or the instance endpoint, as shown.
 
-image:cmi_prometheus_job_config.png[]
+image::cmi_prometheus_job_config.png[]
 
 - Replace the placeholders `<AURA_CLIENT_ID>` and `<AURA_CLIENT_SECRET>` with corresponding values created  in the API credentials section.
 
@@ -41,11 +41,11 @@ image:cmi_prometheus_job_config.png[]
 
 - Check if the metrics endpoints are being successfully connected as targets in Prometheus' UI:
 
-image:cmi_prometheus_targets.png[]
+image::cmi_prometheus_targets.png[]
 
 - Check if any of the Aura metrics are showing up by querying using PromQL and plot the basic graphs:
 
-image:cmi_prometheus_jobs_example.png[]
+image::cmi_prometheus_jobs_example.png[]
 
 .Use Grafana
 

--- a/modules/ROOT/pages/metrics/metrics-integration/process.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/process.adoc
@@ -35,12 +35,12 @@ Capabilities of users with the role "Metrics Integration Reader" are limited to 
 == Customer APM integration
 
 . Optionally configure interested endpoints as decribed in <<cmi-endpoint-config, Metrics endpoint configuration>> before setting up the APM system.
-. To setup an APM system to fetch Aura metrics, click on the `...` in the table view and copy either the endpoint or Prometheus job configuration template(if configuring Prometheus).
+. To setup an APM system to fetch Aura metrics, click on the `...` in the table view and copy either the endpoint URL or Prometheus job configuration template (if configuring Prometheus).
 +
 image::cmi_apm_config_input.png[]
 +
 . Use oauth2 type of authentication specifying the Client ID and Client Secret created in the previous step. See examples for **__Prometheus__** and **__Datadog__** xref:./examples.adoc[here].
-. Once metrics start flowing to APM system, statuses of used endpoints can be viewed in the Metrics integration table. (__See the section about Metrics endpoint configuration below for an example of the status table__)
+. Once metrics start flowing to APM system, statuses of used endpoints can be viewed in the Metrics integration table. __(See the section about Metrics endpoint configuration below for an example of the status table)__
 
 [[cmi-endpoint-config]]
 == Metrics endpoint configuration

--- a/modules/ROOT/pages/metrics/metrics-integration/process.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/process.adoc
@@ -36,11 +36,11 @@ Capabilities of users with the role "Metrics Integration Reader" are limited to 
 
 . Optionally configure interested endpoints as decribed in <<cmi-endpoint-config, Metrics endpoint configuration>> before setting up the APM system.
 . To setup an APM system to fetch Aura metrics, click on the `...` in the table view and copy either the endpoint or Prometheus job configuration template(if configuring Prometheus). +
-image:cmi_apm_config_input.png[]
+image::cmi_apm_config_input.png[]
 +
 . Use oauth2 type of authentication specifying the Client ID and Client Secret created in the previous step. See examples for **__Prometheus__** and **__Datadog__** xref:./examples.adoc[here].
 . Once metrics start flowing to APM system, statuses of used endpoints can be viewed in the Metrics integration table. +
-image:cmi_status_table.png[]
+image::cmi_status_table.png[]
 
 [[cmi-endpoint-config]]
 == Metrics endpoint configuration
@@ -50,7 +50,7 @@ Aura Metrics Integration setup offers two types of metrics endpoints to endpoint
 - **Project metrics endpoint** - A single endpoint with Project level endpoint configuration that allows selecting which instance metrics to include.
 - **Instance metrics endpoint** - Individual endpoint for each of the instances in the Project with corresponding endpoint configuration.
 
-image:cmi_status_table.png[]
+image::cmi_status_table.png[]
 
 Use the __Settings__ button for an endpoint in the table to configure that endpoint.
 
@@ -67,7 +67,7 @@ If your goal is to monitor a subset of instances in the Project and you don't wa
 
 * Project endpoint configuration:
 +
-image:cmi_project_config.png[]
+image::cmi_project_config.png[]
 +
 . `Selecting instances to include in project endpoint` - This is a project endpoint specific setting which allows users to select instances to endpoint metrics for.
 . `Include new instances` - This setting enables scraping for newly created instance without manually updating the Project endpoint configuration.
@@ -76,12 +76,12 @@ It is an on-demand setting only available for Virtual Dedicated Cloud projects a
 
 * Instance endpoint configuration :
 +
-image:cmi_instance_config.png[]
+image::cmi_instance_config.png[]
 +
 . `Metrics granularity` - This setting allows scraping more granular metrics(`Comprehensive`) for each of the instances enabled. 
 It is an on-demand setting only available for Virtual Dedicated Cloud project instances and it needs to be requested through link:https://support.neo4j.com/[Customer Support].
 +
-image:cmi_enable_comprehensive.png[]
+image::cmi_enable_comprehensive.png[]
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/metrics/metrics-integration/process.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/process.adoc
@@ -35,12 +35,12 @@ Capabilities of users with the role "Metrics Integration Reader" are limited to 
 == Customer APM integration
 
 . Optionally configure interested endpoints as decribed in <<cmi-endpoint-config, Metrics endpoint configuration>> before setting up the APM system.
-. To setup an APM system to fetch Aura metrics, click on the `...` in the table view and copy either the endpoint or Prometheus job configuration template(if configuring Prometheus). +
+. To setup an APM system to fetch Aura metrics, click on the `...` in the table view and copy either the endpoint or Prometheus job configuration template(if configuring Prometheus).
++
 image::cmi_apm_config_input.png[]
 +
 . Use oauth2 type of authentication specifying the Client ID and Client Secret created in the previous step. See examples for **__Prometheus__** and **__Datadog__** xref:./examples.adoc[here].
-. Once metrics start flowing to APM system, statuses of used endpoints can be viewed in the Metrics integration table. +
-image::cmi_status_table.png[]
+. Once metrics start flowing to APM system, statuses of used endpoints can be viewed in the Metrics integration table. (__See the section about Metrics endpoint configuration below for an example of the status table__)
 
 [[cmi-endpoint-config]]
 == Metrics endpoint configuration

--- a/modules/ROOT/pages/metrics/metrics-integration/status.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/status.adoc
@@ -9,7 +9,7 @@ Once the endpoints are configured and APM integration is setup, APM starts scrap
 The Metrics integration service records some usage statistics for scraped endpoints. 
 These statistics are presented in the Metrics integration status table :
 
-image:cmi_status_table.png[]
+image::cmi_status_table.png[]
 
 == Status details
 
@@ -18,7 +18,7 @@ image:cmi_status_table.png[]
 . `Status` - indicates the endpoint usage and behaviour. An endpoint status could be one of the following :
     * `Not in use` - indicates the endpoint is not used.
     * `Error` - indicates there has been an error while scraping the endpoint.
-    image:cmi_error_status.png[]
+    image::cmi_error_status.png[]
     **__Hovering over the__ `Error` __status shows 
     the type of error encountered during the scrape.__**
     * `In use` - indicates that the endpoint is most recently scraped wihout any issues.


### PR DESCRIPTION
only `image::` allows image zoom, not `image:`.