### PR TITLE
Document latency metric availability

### DIFF
--- a/modules/ROOT/pages/metrics/metrics-integration/reference.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/reference.adoc
@@ -414,7 +414,7 @@ m| neo4j_db_query_execution_failure_total
 m| SUM
 |===
 
-.Query Latency 99th Percentile
+.Query Latency 99th Percentile (only included for Neo4j Version 5 and later)
 [frame="topbot", stripes=odd, grid="cols", cols="<1,<4"]
 |===
 | Metric name
@@ -427,7 +427,7 @@ m| neo4j_db_query_execution_internal_latency_q99
 m| MAX
 |===
 
-.Query Latency 75th Percentile
+.Query Latency 75th Percentile (only included for Neo4j Version 5 and later)
 [frame="topbot", stripes=odd, grid="cols", cols="<1,<4"]
 |===
 | Metric name
@@ -440,7 +440,7 @@ m| neo4j_db_query_execution_internal_latency_q75
 m| MAX
 |===
 
-.Query Latency 50th Percentile
+.Query Latency 50th Percentile (only included for Neo4j Version 5 and later)
 [frame="topbot", stripes=odd, grid="cols", cols="<1,<4"]
 |===
 | Metric name
@@ -469,7 +469,7 @@ It should show overlapping, ever-increasing lines and if one of the lines levels
 m| MAX
 |===
 
-.Cluster Leader (only included if <<_metrics_granularity,high granularity>> is turned on)
+.Cluster Leader (only included if xref:introduction.adoc#aura-cmi-metrics-granularity[high granularity] is turned on)
 [frame="topbot", stripes=odd, grid="cols", cols="<1,<4"]
 |===
 | Metric name


### PR DESCRIPTION
[Trello card](https://trello.com/c/tSg4iaEf/2783-cmi-mention-in-the-docs-that-query-latency-percentile-metrics-are-only-available-for-neo4j-latest)