### PR TITLE
Apply official product naming

### DIFF
--- a/modules/ROOT/pages/graph-analytics/index.adoc
+++ b/modules/ROOT/pages/graph-analytics/index.adoc
@@ -62,7 +62,7 @@ You can use Aura Graph Analytics from any AuraDB Business Critical or AuraDB Vir
 [[get-started-serverless]]
 === Getting started
 
-With Graph Analytics Serverless enabled in your organization, you only need to create xref:api/authentication.adoc#_creating_credentials[Aura API credentials] before you can get started.
+With Aura Graph Analytics enabled in your organization, you only need to create xref:api/authentication.adoc#_creating_credentials[Aura API credentials] before you can get started.
 
 With the Aura API credentials available:
 

--- a/modules/ROOT/pages/graph-analytics/index.adoc
+++ b/modules/ROOT/pages/graph-analytics/index.adoc
@@ -6,11 +6,11 @@
 
 If your data is in Aura or you plan to move it to Aura, you have several options to run graph analytics:
 
-* Enable <<aura-gds-plugin,Graph Analytics>> on an existing AuraDB instance (Professional).
-* Use <<aura-gds-serverless,Graph Analytics Serverless>> from an existing AuraDB instance (Business Critical, Virtual Dedicated Cloud).
-* Create an <<aura-ds, AuraDS instance>> (Professional, Enterprise).
+* Enable the <<aura-gds-plugin,Graph Analytics plugin>> on an existing AuraDB instance (Professional).
+* Use <<aura-gds-serverless,Aura Graph Analytics>> from an existing AuraDB instance (Business Critical, Virtual Dedicated Cloud).
+* Create an <<aura-ds,AuraDS instance>> (Professional, Enterprise).
 
-If your data is in a self-managed Neo4j DBMS or a non-Neo4j data source, you can still use <<aura-gds-serverless,Graph Analytics Serverless>>.
+If your data is in a self-managed Neo4j DBMS or a non-Neo4j data source, you can still use <<aura-gds-serverless, Aura Graph Analytics>>.
 
 [[aura-gds-plugin]]
 == Graph Analytics plugin
@@ -37,12 +37,12 @@ With the Graph Analytics plugin enabled:
 * If you use Python, start with the link:{neo4j-docs-base-uri}/graph-data-science-client/current/tutorials/tutorials/[Python client tutorials].
 
 [[aura-gds-serverless]]
-== Graph Analytics Serverless
+== Aura Graph Analytics
 
-Graph Analytics Serverless allows you to use the Graph Data Science library regardless of where your source data is stored.
+Aura Graph Analytics allows you to use the Graph Data Science library regardless of where your source data is stored.
 It runs in Aura as a link:{gds-sessions-page}[dedicated service] optimised for analytics workloads, with no memory or compute resources shared with your data store.
 
-You can enable, disable, and configure Graph Analytics Serverless on the organization level in the xref:visual-tour/index.adoc#_settings_for_graph_analytics_serverless[organization settings].
+You can enable, disable, and configure Aura Graph Analytics serverless on the organization level in the xref:visual-tour/index.adoc#_settings_for_graph_analytics_serverless[organization settings].
 The details on any running sessions are available in the xref:visual-tour/index.adoc#_graph_analytics[Graph Analytics] page.
 
 === From an AuraDB instance
@@ -51,10 +51,10 @@ label:AuraDB-Business-Critical[] label:AuraDB-Virtual-Dedicated-Cloud[]
 
 [IMPORTANT]
 ====
-Graph Analytics Serverless is currently unavailable via any of the xref:cloud-providers.adoc[cloud provider marketplaces].
+Aura Graph Analytics is currently unavailable via any of the xref:cloud-providers.adoc[cloud provider marketplaces].
 ====
 
-You can use Graph Analytics Serverless from any AuraDB Business Critical or AuraDB Virtual Dedicated Cloud instance with the following requirements:
+You can use Aura Graph Analytics serverless from any AuraDB Business Critical or AuraDB Virtual Dedicated Cloud instance with the following requirements:
 
 * Neo4j version 5 or later
 * All supported cloud providers and regions
@@ -111,9 +111,9 @@ Graphs and models created or updated _after_ the instance update/upgrade process
 |
 |Graph Analytics plugin +
 (AuraDB Pro)
-|Graph Analytics Serverless +
+|Aura Graph Analytics serverless +
 (AuraDB BC)
-|Graph Analytics Serverless +
+|Aura Graph Analytics serverless +
 (AuraDB VDC)
 |AuraDS
 

--- a/modules/ROOT/pages/graph-analytics/index.adoc
+++ b/modules/ROOT/pages/graph-analytics/index.adoc
@@ -42,7 +42,7 @@ With the Graph Analytics plugin enabled:
 Aura Graph Analytics allows you to use the Graph Data Science library regardless of where your source data is stored.
 It runs in Aura as a link:{gds-sessions-page}[dedicated service] optimised for analytics workloads, with no memory or compute resources shared with your data store.
 
-You can enable, disable, and configure Aura Graph Analytics serverless on the organization level in the xref:visual-tour/index.adoc#_settings_for_graph_analytics_serverless[organization settings].
+You can enable, disable, and configure Aura Graph Analytics on the organization level in the xref:visual-tour/index.adoc#_settings_for_graph_analytics_serverless[organization settings].
 The details on any running sessions are available in the xref:visual-tour/index.adoc#_graph_analytics[Graph Analytics] page.
 
 === From an AuraDB instance
@@ -54,7 +54,7 @@ label:AuraDB-Business-Critical[] label:AuraDB-Virtual-Dedicated-Cloud[]
 Aura Graph Analytics is currently unavailable via any of the xref:cloud-providers.adoc[cloud provider marketplaces].
 ====
 
-You can use Aura Graph Analytics serverless from any AuraDB Business Critical or AuraDB Virtual Dedicated Cloud instance with the following requirements:
+You can use Aura Graph Analytics from any AuraDB Business Critical or AuraDB Virtual Dedicated Cloud instance with the following requirements:
 
 * Neo4j version 5 or later
 * All supported cloud providers and regions
@@ -111,9 +111,9 @@ Graphs and models created or updated _after_ the instance update/upgrade process
 |
 |Graph Analytics plugin +
 (AuraDB Pro)
-|Aura Graph Analytics serverless +
+|Aura Graph Analytics +
 (AuraDB BC)
-|Aura Graph Analytics serverless +
+|Aura Graph Analytics +
 (AuraDB VDC)
 |AuraDS
 

--- a/modules/ROOT/pages/visual-tour/index.adoc
+++ b/modules/ROOT/pages/visual-tour/index.adoc
@@ -41,11 +41,11 @@ Management at this level allows control over all Projects within an Organization
 [[org-settings]]
 === Organization settings
 
-On the organization level, you can also find a Settings menu where you can manage your organization's settings, provided that you are an organization admin. 
+On the organization level, you can also find a Settings menu where you can manage your organization's settings, provided that you are an organization admin.
 You can change the name of the organization and toggle an organization-wide setting for Generative AI assistance.
 
 
-When enabled, Generative AI assistance is available in a number of places, including the xref:query/visual-tour.adoc#copilot[Query copilot] and xref:explore/explore-visual-tour/search-bar.adoc#copilot[Explore copilot]. 
+When enabled, Generative AI assistance is available in a number of places, including the xref:query/visual-tour.adoc#copilot[Query copilot] and xref:explore/explore-visual-tour/search-bar.adoc#copilot[Explore copilot].
 These features are always identified with a ✨ and your use is subject to our link:{neo4j-docs-base-uri}/reference/license/#_genai_outputs[GenAI outputs] disclaimer
 
 // TO-DO: When section exists for Import GenAI feature, add link to it.
@@ -53,9 +53,9 @@ These features are always identified with a ✨ and your use is subject to our l
 .Organization settings
 image::organizationsettings.png[]
 
-==== Graph Analytics Serverless settings
+==== Aura Graph Analytics settings
 
-From this page you can enable or disable link:{gds-sessions-page}[Graph Analytics Serverless], as well as configure the following settings:
+From this page you can enable or disable link:{gds-sessions-page}[Aura Graph Analytics], as well as configure the following settings:
 
 * The maximum available memory for each session
 * The maximum number of concurrent sessions within the organization
@@ -82,7 +82,7 @@ See the xref:import/introduction.adoc[What is Import?] for more information abou
 
 === Graph Analytics
 
-This page lists the link:{gds-sessions-page}[Graph Analytics Serverless] sessions running within a project (if any).
+This page lists the link:{gds-sessions-page}[Aura Graph Analytics] sessions running within a project (if any).
 
 The list shows session details and a **Delete** button for each session.
 Session details include:


### PR DESCRIPTION
Aura Graph Analytics is the product name.
Serverless should be only used in descriptions.

[trello](https://trello.com/c/0D3YcJ5T/10794-naming-clean-up-for-graph-analytics-in-console-docs)
