### PR TITLE
Update ip addresses for europe-west3

### DIFF
--- a/modules/ROOT/pages/security/ip-addresses.adoc
+++ b/modules/ROOT/pages/security/ip-addresses.adoc
@@ -137,7 +137,8 @@ For AuraDS Enterprise also add port 8491.
 
 |`europe-west3`
 |35.246.176.187 +
-35.242.209.97
+35.242.209.97 +
+34.159.4.179
 |80,443,7474,7687
 
 |`us-central1`


### PR DESCRIPTION
We have added more resources in GCP in region europe-west3. This PR contains an update to the public IP address documentation to account for the new resources.