### PR TITLE
Infra/update ip for new orchestras

### DIFF
--- a/modules/ROOT/pages/security/ip-addresses.adoc
+++ b/modules/ROOT/pages/security/ip-addresses.adoc
@@ -322,6 +322,10 @@ For AuraDS Enterprise also add port 8491.
 |52.151.91.171	
 |80,443,7474,7687
 
+|`westeurope`
+128.251.205.62
+|80,443,7474,7687
+
 |===
 
 == Fully qualified domain name

--- a/modules/ROOT/pages/security/ip-addresses.adoc
+++ b/modules/ROOT/pages/security/ip-addresses.adoc
@@ -178,6 +178,7 @@ For AuraDS Enterprise also add port 8491.
 
 |`asia-south1`	
 |35.200.158.141	
+|34.47.152.14
 |80,443,7474,7687
 
 |`australia-southeast1`


### PR DESCRIPTION
Add IP addresses for 2 newly provisioned orchestras:
- production-orch-1142 - azure/westeurope: ['128.251.205.62']
- production-orch-1143 - gcp/asia-south1: ['34.47.152.14']