### PR TITLE
Add CMI capability to the roles table

### DIFF
--- a/modules/ROOT/pages/metrics/metrics-integration/process.adoc
+++ b/modules/ROOT/pages/metrics/metrics-integration/process.adoc
@@ -50,6 +50,7 @@ For examples using Prometheus and Datadog, see xref:./examples.adoc[Examples].
 [NOTE]
 ====
 To change the metrics endpoint configuration, you need to have the _Project Admin_ role in the project.
+To access the metrics, the _Metrics Reader_ role is required.
 ====
 
 Aura Metrics Integration setup offers two types of metrics endpoints to endpoint Aura instance metrics:

--- a/modules/ROOT/pages/user-management.adoc
+++ b/modules/ROOT/pages/user-management.adoc
@@ -247,6 +247,12 @@ The `METRICS_READER` role can view and open instances in the console, however, l
 |
 |
 | {check-mark}
+
+| Access Prometheus metrics endpoint
+|
+| {check-mark}
+|
+|
 |===
 
 === Predefined roles


### PR DESCRIPTION
see [Slack thread](https://neo4j.slack.com/archives/C027CMVCKB6/p1744717112303619?thread_ts=1744714699.616309&cid=C027CMVCKB6), it would be good to have a dedicated line in the capabilities table that emphasizes the fact that only users with METRICS_READER role can access the Prometheus endpoint.