### PR TITLE
Regions output fix

### DIFF
--- a/modules/ROOT/pages/managing-instances/regions.adoc
+++ b/modules/ROOT/pages/managing-instances/regions.adoc
@@ -1,3 +1,5 @@
+// Note that the regions listed in the tables on this page are automatically generated
+// from JSON during the asciidoc to HTML conversion.
 [[regions]]
 = Regions
 :description: This page lists all regions Aura supports deployment in, sorted by tier.

--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -117,10 +117,10 @@ module.exports.register = function ({ config }) {
             extname: '.adoc',
         };
 
-        file.out = {
-            path: `${componentName}/${componentVersion}/${moduleName}/${regionsPartialFilename.replace('.adoc', '.html')}`,
-            url: `${componentName}/${componentVersion}/${moduleName}/${regionsPartialFilename.replace('.adoc', '.html')}`,
-        };
+        // file.out = {
+        //     path: `${componentName}/${componentVersion}/${moduleName}/${regionsPartialFilename.replace('.adoc', '.html')}`,
+        //     url: `${componentName}/${componentVersion}/${moduleName}/${regionsPartialFilename.replace('.adoc', '.html')}`,
+        // };
   
         file.family = family;
 


### PR DESCRIPTION
We should prevent the generated HTML from actually being written as a file in the build/site directory.