### PR TITLE
Update list of supported Azure CMK regions

### DIFF
--- a/modules/ROOT/pages/security/encryption.adoc
+++ b/modules/ROOT/pages/security/encryption.adoc
@@ -134,7 +134,7 @@ To enable automatic key rotation in the AWS KMS, tick the *Key rotation* checkbo
 [IMPORTANT]
 ====
 Aura supports Customer Managed Keys in the following regions:
-`Australia East`, `Southeast Asia`, `Canada Central`, `North Europe`, `Germany West Central`, `Korea Central`, `Sweden Central`, `UK South`, `West US`, `Central US`
+`Southeast Asia`, `North Europe`, `Germany West Central`, `UK South`, `Central US`
 ====
 
 === Create an Azure key vault


### PR DESCRIPTION
As we confirmed with Azure support (and they've now updated their [docs](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-cross-tenant-customer-managed-keys?tabs=azure-portal#preview-regional-availability)), the actual list of supported regions is Australia South East, Southeast Asia, North Europe, Germany West Central, UK South, Central US, UAE North.