### PR TITLE
Customer Managed Keys now supported in all Azure regions

### DIFF
--- a/modules/ROOT/pages/security/customer-managed-keys.adoc
+++ b/modules/ROOT/pages/security/customer-managed-keys.adoc
@@ -119,12 +119,6 @@ To enable automatic key rotation in the AWS KMS, tick the *Key rotation* checkbo
 
 == Azure keys
 
-[IMPORTANT]
-====
-Aura supports Customer Managed Keys in the following regions:
-`Australia Southeast`, `Southeast Asia`, `North Europe`, `Germany West Central`, `UK South`, `Central US`, `UAE North`.
-====
-
 === Create an Azure key vault
 
 Create a Key Vault in the Azure portal ensuring the region matches your Aura database instance region.


### PR DESCRIPTION
Removes the note listing specific Azure regions as the only ones that support Customer Managed Keys. CMK is now available in all Azure regions.