### PR TITLE
Update API Keys page reference to Client credentials

### DIFF
--- a/modules/ROOT/pages/api/authentication.adoc
+++ b/modules/ROOT/pages/api/authentication.adoc
@@ -10,12 +10,12 @@ All tiers can create Aura API credentials.
 API credentials are linked to the user account, inheriting its capabilities and roles.
 The API credentials never expire unless you delete them.
 
-To create credentials in the Aura console go to the https://console.neo4j.io/account/api-keys[API Keys page] in your browser, or:
+To create credentials in the Aura console go to the https://console.neo4j.io/account/api-keys[Client credentials page] in your browser, or:
 
 * Go to your profile menu from the top right corner of your screen
 * Select *Account Settings*
-* Select the *API Keys* tab
-* Select the *Generate API key* button
+* Select the *Client credentials* tab
+* Select the *Create client credential* button
 * Enter a Client *Name*, and select *Create*.
 * *Save* the Client ID and Client Secret you are given in the resulting modal.
 


### PR DESCRIPTION
The API keys tab in Account settings has been renamed to Client credentials. Update the docs accordingly. 