### PR TITLE
Add mention of Arrow port to AGA docs page

### DIFF
--- a/modules/ROOT/pages/graph-analytics/aga.adoc
+++ b/modules/ROOT/pages/graph-analytics/aga.adoc
@@ -21,6 +21,16 @@ Here you can also configure:
 * The maximum available memory for each session
 * The maximum number of concurrent sessions within the organization
 
+=== Network requirements
+
+Aura Graph Analytics sessions communicate with your AuraDB instance (or external data source) using the Apache Arrow Flight protocol for remote projections and write-back.
+
+[NOTE]
+====
+If your network enforces firewall rules or restricts outbound traffic, you must also allow TCP port `8491` for Apache Arrow, in addition to the standard ports for your instance.
+See xref:security/ip-addresses.adoc[Aura IP addresses and ports] for the full list of IP addresses and ports required.
+====
+
 === User management
 
 Aura Console roles map to user privileges in Aura Graph Analytics sessions as described in xref:user-management.adoc#graph-analytics-roles[Graph Analytics roles].


### PR DESCRIPTION
@nvitucci feel free to edit as needed - otherwise ready to be merged.

Context behind the PR: many customers aren't aware that this port is needed for AGA, so making this info part of the AGA-specific page.