### PR TITLE
DOCOPS-176 Add page-tabs attributes to antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -5,3 +5,7 @@ display_version: current
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
+asciidoc:
+  attributes:
+    page-tabs: administration@
+    page-tabs-index: 40

--- a/antora.yml
+++ b/antora.yml
@@ -8,4 +8,4 @@ nav:
 asciidoc:
   attributes:
     page-tabs: administration@
-    page-tabs-index: 40
+    page-tabs-index: 10

--- a/publish.yml
+++ b/publish.yml
@@ -33,6 +33,8 @@ asciidoc:
   - "@neo4j-antora/antora-add-notes"
 
   attributes:
+    page-tabs: administration@
+    page-tabs-index: 40
     page-theme: docs
     page-type: Docs
     page-search-type: Docs

--- a/publish.yml
+++ b/publish.yml
@@ -33,8 +33,6 @@ asciidoc:
   - "@neo4j-antora/antora-add-notes"
 
   attributes:
-    page-tabs: administration@
-    page-tabs-index: 40
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `antora.yml`:

```yaml
asciidoc:
  attributes:
    page-tabs: administration@
    page-tabs-index: 40
```

Places this docset in the `administration` tab of the aggregated tabbed navigation,
at the position matching its order in the Docs menu on neo4j.com/docs. The values
are soft-set with a trailing `@` so they can be overridden on an individual page.

Set in `antora.yml` rather than the publish playbook so they apply to every build of
this component, independent of which playbook generates the HTML. This is safe here
because Aura docs are versionless and publish from a single branch.
